### PR TITLE
capitalize label in hook_config_info

### DIFF
--- a/domain.module
+++ b/domain.module
@@ -4479,7 +4479,7 @@ function domain_autoload_info() {
  */
 function domain_config_info() {
   $prefixes['domain.settings'] = [
-    'label' => t('domain settings'),
+    'label' => t('Domain settings'),
     'group' => t('Configuration'),
   ];
   return $prefixes;


### PR DESCRIPTION
hey, i noticed the label was showing up lowercase in the config list and looked out of order. changed "domain settings" to "Domain settings" so it sorts properly with the other D items. 

pretty quick fix, should be good now. let me know if you need anything else 👍