### PR TITLE
Improve domain response check UX for local dev environments

### DIFF
--- a/domain.admin.inc
+++ b/domain.admin.inc
@@ -318,6 +318,13 @@ function domain_configure_form($form, &$form_state, $user_submitted = FALSE) {
       easier to support. Use at your own risk.</em>'),
   ];
 
+  $form['domain_advanced']['domain_skip_domain_check'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Disable domain response check'),
+    '#default_value' => $config->get('domain_skip_domain_check'),
+    '#description' => t('When saving a domain, the module verifies the domain is reachable by making an HTTP request to it. Check this box to skip that check. Useful for local development environments where domains may not be reachable from the server.'),
+  ];
+
   $options = ['-1' => t('Do not change domain')];
   foreach (domain_domains() as $data) {
     // The domain must be valid.
@@ -439,6 +446,7 @@ function domain_configure_form_submit($form, &$form_state, $user_submitted = FAL
   $config->set('domain_search', $form_state['values']['domain_search']);
   $config->set('domain_seo', $form_state['values']['domain_seo']);
   $config->set('domain_edit_on_primary', $form_state['values']['domain_edit_on_primary']);
+  $config->set('domain_skip_domain_check', $form_state['values']['domain_skip_domain_check']);
   $config->set('domain_default_source', $form_state['values']['domain_default_source']);
   $config->set('domain_grant_all', $form_state['values']['domain_grant_all']);
   $config->set('domain_cron_rule', $form_state['values']['domain_cron_rule']);

--- a/domain.module
+++ b/domain.module
@@ -3769,6 +3769,11 @@ function domain_check_response($domain, $drush = FALSE) {
     'absolute' => TRUE,
   ]);
   if ($response->code != 200) {
+    if ($response->code == 0) {
+      return $t('!server could not be reached (connection failed). This is common in local development environments where the server cannot make HTTP requests to itself. You can disable this check at <a href="!url">Domain settings</a>.',
+        ['!server' => $url, '!url' => url('admin/structure/domain/settings')]
+      );
+    }
     return $t('!server is not responding as expected and may not be configured correctly at the server level. Server code !code was returned.',
       ['!server' => $url, '!code' => $response->code]
     );


### PR DESCRIPTION
- Expose the domain_skip_domain_check setting in the Advanced settings form (admin/structure/domain/settings) so site architects can disable the HTTP response check without editing config files directly.

- Distinguish code 0 (connection failed) from other non-200 responses with a clearer error message and a direct link to Domain settings. Code 0 is common in local dev environments where the server cannot make outbound HTTP requests to itself.

Fixes #33.