### PR TITLE
#36 - Fix redirect message lost on cross-domain redirect to primary domain

### DIFF
--- a/domain.admin.inc
+++ b/domain.admin.inc
@@ -22,6 +22,14 @@ function domain_overview_form($form, &$form_state) {
   // Set the form.
   $default = domain_default();
   $active_domain = domain_get_domain();
+
+  // Warn when viewing domain administration from a non-primary domain.
+  // Changes to domain settings require being on the primary domain; alerting
+  // the user here avoids a confusing redirect later when they try to edit.
+  if ($active_domain['domain_id'] != $default['domain_id']) {
+    $primary_url = domain_get_uri($default) . 'admin/structure/domain';
+    backdrop_set_message(t('Domain settings can only be changed from the primary domain. <a href="!url">Switch to the primary domain</a> to make changes.', ['!url' => $primary_url]), 'warning', FALSE);
+  }
   $form = [];;
   $form['top'] = [
     '#markup' => t('<p>The following domains have been created for your site.  The currently active domain <strong>is shown in boldface</strong>.  You

--- a/domain.module
+++ b/domain.module
@@ -133,6 +133,14 @@ function domain_init() {
     domain_invalid_domain_requested();
   }
 
+  // Display a redirect message passed via URL from a cross-domain redirect.
+  // backdrop_set_message() cannot survive a cross-domain redirect because
+  // sessions are not shared across domain boundaries. The message is instead
+  // passed as a query parameter and displayed here on the destination domain.
+  if (!empty($_GET['domain_redirect_msg'])) {
+    backdrop_set_message(t('To edit these settings you must be on your primary domain. You have been redirected there.'));
+  }
+
   // Set the site name to the domain-specific name.
   if ($config->get('domain_sitename_override')) {
     $GLOBALS['config']['system.core']['site_name'] = $_domain['sitename'];
@@ -1629,7 +1637,12 @@ function domain_check_primary($msg = 'default') {
   $default = domain_default();
   if ($_domain['domain_id'] != $default['domain_id']) {
     if ($msg == 'default') {
-      backdrop_set_message(t('You have been redirected: This page must be accessed from the primary domain.'));
+      // Pass a flag in the redirect URL rather than calling backdrop_set_message()
+      // here. Session messages set before a cross-domain redirect are stored in
+      // the source domain's session and never appear on the destination domain.
+      // The flag is caught in domain_init() after the redirect completes.
+      $path = domain_get_uri($default);
+      backdrop_goto($path, ['query' => ['domain_redirect_msg' => 1]]);
     }
     elseif (!empty($msg)) {
       backdrop_set_message($msg);


### PR DESCRIPTION
Session messages set before a cross-domain redirect are stored in the source domain's session and never appear on the destination domain.

- Pass a flag (domain_redirect_msg=1) in the redirect URL instead of calling backdrop_set_message() before the redirect. domain_init() catches the flag on arrival and displays the message correctly.

- Add a proactive warning on admin/structure/domain when visited from a non-primary domain, with a direct link to switch to the primary domain before attempting any changes.

- Update redirect message wording to be clearer about why the redirect occurred.

Fixes #36.